### PR TITLE
Remove trailing slashes from API endpoints.

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -2384,7 +2384,7 @@
         ]
       }
     },
-    "/instruments/":{
+    "/instruments":{
       "get":{
         "tags":[
           "instruments"
@@ -3249,7 +3249,7 @@
         ]
       }
     },
-    "/object_set/":{
+    "/object_set":{
       "delete":{
         "tags":[
           "objects"
@@ -4107,7 +4107,7 @@
         ]
       }
     },
-    "/jobs/":{
+    "/jobs":{
       "get":{
         "tags":[
           "jobs"
@@ -4162,7 +4162,7 @@
         ]
       }
     },
-    "/jobs/{job_id}/":{
+    "/jobs/{job_id}":{
       "get":{
         "tags":[
           "jobs"
@@ -4192,6 +4192,54 @@
                 "schema":{
                   "$ref":"#/components/schemas/JobModel"
                 }
+              }
+            }
+          },
+          "422":{
+            "description":"Validation Error",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "$ref":"#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security":[
+          {
+            "BearerOrCookieAuth":[]
+          }
+        ]
+      },
+      "delete":{
+        "tags":[
+          "jobs"
+        ],
+        "summary":"Erase Job",
+        "description":"**Delete the job** from DB, with associated storage.\n\nReturn **NULL upon success.**\n\nIf the job is running then kill it.\n\n🔒 The job must be accessible to current user.",
+        "operationId":"erase_job",
+        "parameters":[
+          {
+            "description":"Internal, the unique numeric id of this job.",
+            "required":true,
+            "schema":{
+              "title":"Job Id",
+              "type":"integer",
+              "description":"Internal, the unique numeric id of this job."
+            },
+            "example":47445,
+            "name":"job_id",
+            "in":"path"
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"Successful Response",
+            "content":{
+              "application/json":{
+                "schema":{},
+                "example":{}
               }
             }
           },
@@ -4424,56 +4472,6 @@
         ]
       }
     },
-    "/jobs/{job_id}":{
-      "delete":{
-        "tags":[
-          "jobs"
-        ],
-        "summary":"Erase Job",
-        "description":"**Delete the job** from DB, with associated storage.\n\nReturn **NULL upon success.**\n\nIf the job is running then kill it.\n\n🔒 The job must be accessible to current user.",
-        "operationId":"erase_job",
-        "parameters":[
-          {
-            "description":"Internal, the unique numeric id of this job.",
-            "required":true,
-            "schema":{
-              "title":"Job Id",
-              "type":"integer",
-              "description":"Internal, the unique numeric id of this job."
-            },
-            "example":47445,
-            "name":"job_id",
-            "in":"path"
-          }
-        ],
-        "responses":{
-          "200":{
-            "description":"Successful Response",
-            "content":{
-              "application/json":{
-                "schema":{},
-                "example":{}
-              }
-            }
-          },
-          "422":{
-            "description":"Validation Error",
-            "content":{
-              "application/json":{
-                "schema":{
-                  "$ref":"#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        },
-        "security":[
-          {
-            "BearerOrCookieAuth":[]
-          }
-        ]
-      }
-    },
     "/my_files/{sub_path}":{
       "get":{
         "tags":[
@@ -4522,7 +4520,7 @@
         ]
       }
     },
-    "/my_files/":{
+    "/my_files":{
       "post":{
         "tags":[
           "Files"
@@ -4571,7 +4569,7 @@
         ]
       }
     },
-    "/common_files/":{
+    "/common_files":{
       "get":{
         "tags":[
           "Files"

--- a/py/main.py
+++ b/py/main.py
@@ -1098,7 +1098,7 @@ def acquisition_query(
 
 # ######################## END OF ACQUISITION
 
-@app.get("/instruments/",
+@app.get("/instruments",
          operation_id="instrument_query", tags=['instruments'],
          response_model=List[str],
          responses={
@@ -1511,7 +1511,7 @@ def predict_object_set(filters: ProjectFiltersModel = Body(...),
 #     return rsp
 
 
-@app.delete("/object_set/", operation_id="erase_object_set", tags=['objects'],
+@app.delete("/object_set", operation_id="erase_object_set", tags=['objects'],
             responses={
                 200: {
                     "content": {
@@ -1968,7 +1968,7 @@ def machine_learning_train(project_id: int = Query(..., title="Input project #",
 
 # ######################## END OF ADMIN
 
-@app.get("/jobs/", operation_id="list_jobs", tags=['jobs'], response_model=List[JobModel])
+@app.get("/jobs", operation_id="list_jobs", tags=['jobs'], response_model=List[JobModel])
 def list_jobs(for_admin: bool = Query(..., title="For admin",
                                       description="If FALSE return the jobs for current user, else return all of them.",
                                       example=False),
@@ -1982,7 +1982,7 @@ def list_jobs(for_admin: bool = Query(..., title="For admin",
     return ret
 
 
-@app.get("/jobs/{job_id}/", operation_id="get_job", tags=['jobs'], response_model=JobModel)
+@app.get("/jobs/{job_id}", operation_id="get_job", tags=['jobs'], response_model=JobModel)
 def get_job(job_id: int = Path(..., description="Internal, the unique numeric id of this job.", example=47445),
             current_user: int = Depends(get_current_user)) -> JobBO:
     """
@@ -2130,7 +2130,7 @@ async def list_user_files(sub_path: str = Query(..., title="Sub path", descripti
     return file_list
 
 
-@app.post("/my_files/", operation_id="post_user_file", tags=['Files'],
+@app.post("/my_files", operation_id="post_user_file", tags=['Files'],
           responses={
               200: {
                   "content": {
@@ -2160,7 +2160,7 @@ async def put_user_file(file: UploadFile = File(..., title="File", description="
         return file_name
 
 
-@app.get("/common_files/", operation_id="list_common_files", tags=['Files'], response_model=DirectoryModel)
+@app.get("/common_files", operation_id="list_common_files", tags=['Files'], response_model=DirectoryModel)
 async def list_common_files(
         path: str = Query(..., title="path", description="", example="/ftp_plankton/Ecotaxa_Exported_data"),
         current_user: int = Depends(get_current_user)) -> DirectoryModel:


### PR DESCRIPTION
This change required a slight reordering of openapi.json to avoid duplicate keys.

Fixes #35.