### PR TITLE
Tests classif update

### DIFF
--- a/QA/py/requirements.txt
+++ b/QA/py/requirements.txt
@@ -56,7 +56,7 @@ scikit-learn==1.0
 #tensorflow-hub==0.12.0
 #tensorflow_addons==0.14.0
 # Used same place as TF, CNN generation
-#pandas==1.3.3
+pandas==1.3.3
 ##lycon==0.2.0 # Conflicts with the version required by TF
 #opencv-python-headless==4.5.3.56
 #imgaug==0.4.0

--- a/QA/py/tests/test_classification.py
+++ b/QA/py/tests/test_classification.py
@@ -272,6 +272,19 @@ def test_classif(config, database, fastapi, caplog):
                            'used_taxa': [
                                25835]}]  # <- copepod is gone, unclassified as well, replaced with entomobryomorpha
 
+    # Reset to predicted on validated objects
+    url = OBJECT_SET_RESET_PREDICTED_URL.format(project_id=prj_id)
+    rsp = fastapi.post(url, headers=ADMIN_AUTH, json={})
+    assert rsp.status_code == status.HTTP_200_OK
+    stats = rsp.json()
+    
+    assert get_stats(fastapi, prj_id) == {'nb_dubious': 0,
+                                          'nb_predicted': 8,
+                                          'nb_unclassified': 0,
+                                          'nb_validated': 0,
+                                          'projid': prj_id,
+                                          'used_taxa': [25835]}
+  
     # Delete some object via API, why not?
     rsp = fastapi.delete(OBJECT_SET_DELETE_URL, headers=ADMIN_AUTH, json=obj_ids[:4])
     assert rsp.status_code == status.HTTP_200_OK
@@ -293,7 +306,7 @@ def test_classif(config, database, fastapi, caplog):
     ref_stats = [{"projid": prj_id,
                   "annotators": [{"id": 1,
                                   "name": "Application Administrator"}],
-                  "activities": [{"id": 1, "nb_actions": 8,
+                  "activities": [{"id": 1, "nb_actions": 12,
                                   "last_annot": "2022-05-12T14:21:15"}]}]
     # Fix the date on both sides
     ref_stats[0]["activities"][0]["last_annot"] = "FIXED DATE"

--- a/QA/py/tests/test_classification.py
+++ b/QA/py/tests/test_classification.py
@@ -227,6 +227,13 @@ def test_classif(config, database, fastapi, caplog):
     rsp = fastapi.get(url, headers=ADMIN_AUTH)
     assert rsp.status_code == status.HTTP_200_OK
     assert rsp.json()['classif_auto_score'] == 0.8
+    
+    assert get_stats(fastapi, prj_id) == {'nb_dubious': 0,
+                                          'nb_predicted': 4,
+                                          'nb_unclassified': 4,
+                                          'nb_validated': 0,
+                                          'projid': prj_id,
+                                          'used_taxa': [-1, crustacea]}
 
     # Admin (me!) thinks that all is a copepod :)
     classify_all(fastapi, obj_ids, copepod_id)

--- a/QA/py/tests/test_classification.py
+++ b/QA/py/tests/test_classification.py
@@ -237,7 +237,7 @@ def test_classif(config, database, fastapi, caplog):
                                           'nb_unclassified': 0,
                                           'nb_validated': 8,
                                           'projid': prj_id,
-                                          'used_taxa': [25828]}  # No more Unclassified and Copepod is in +
+                                          'used_taxa': [copepod_id]}  # No more Unclassified and Copepod is in +
 
     # No history yet as the object was just created
     classif = classif_history(fastapi, obj_ids[0])
@@ -245,7 +245,7 @@ def test_classif(config, database, fastapi, caplog):
     assert classif[0]['classif_date'] is not None  # e.g. 2021-09-12T09:28:03.278626
     classif[0]['classif_date'] = "now"
     assert classif == [
-        {'objid': obj_ids[0], 'classif_id': 12846, 'classif_date': 'now', 'classif_who': None,
+        {'objid': obj_ids[0], 'classif_id': crustacea, 'classif_date': 'now', 'classif_who': None,
          'classif_type': 'A', 'classif_qual': 'P', 'classif_score': 0.52, 'user_name': None, 'taxon_name': 'Crustacea'}]
     
     # Revert on validated objects
@@ -295,7 +295,7 @@ def test_classif(config, database, fastapi, caplog):
     classif2[0]['classif_date'] = 'hopefully just now'
     classif2[1]['classif_date'] = 'a bit before'
     assert classif2 == [{'classif_date': 'hopefully just now',
-                         'classif_id': 25828,
+                         'classif_id': copepod_id,
                          'classif_qual': 'V',
                          'classif_score': None,
                          'classif_type': 'M',
@@ -304,7 +304,7 @@ def test_classif(config, database, fastapi, caplog):
                          'taxon_name': 'Copepoda',
                          'user_name': 'Application Administrator'},
                         {'classif_date': 'a bit before',
-                         'classif_id': 12846,
+                         'classif_id': crustacea,
                          'classif_qual': 'P',
                          'classif_score': 0.52,
                          'classif_type': 'A',
@@ -328,8 +328,8 @@ def test_classif(config, database, fastapi, caplog):
                            'nb_unclassified': 0,
                            'nb_validated': 8,
                            'projid': prj_id,
-                           'used_taxa': [
-                               25835]}]  # <- copepod is gone, unclassified as well, replaced with entomobryomorpha
+                           'used_taxa': 
+                           [entomobryomorpha_id]}]  # <- copepod is gone, unclassified as well, replaced with entomobryomorpha
     
     # Reset to predicted on validated objects
     url = OBJECT_SET_RESET_PREDICTED_URL.format(project_id=prj_id)
@@ -342,7 +342,7 @@ def test_classif(config, database, fastapi, caplog):
                                           'nb_unclassified': 0,
                                           'nb_validated': 0,
                                           'projid': prj_id,
-                                          'used_taxa': [25835]}
+                                          'used_taxa': [entomobryomorpha_id]}
     
     # Revert after reset to predicted
     url = OBJECT_SET_REVERT_URL.format(project_id=prj_id, dry_run=False, tgt_usr="")
@@ -355,7 +355,7 @@ def test_classif(config, database, fastapi, caplog):
                                           'nb_unclassified': 0,
                                           'nb_validated': 8,
                                           'projid': prj_id,
-                                          'used_taxa': [25835]}
+                                          'used_taxa': [entomobryomorpha_id]}
   
     # Delete some object via API, why not?
     rsp = fastapi.delete(OBJECT_SET_DELETE_URL, headers=ADMIN_AUTH, json=obj_ids[:4])

--- a/QA/py/tests/test_prediction.py
+++ b/QA/py/tests/test_prediction.py
@@ -1,9 +1,17 @@
 import logging
+import pytest
+import pandas as pd
+import numpy as np
 
 from starlette import status
 
-from tests.credentials import ADMIN_AUTH
+from tests.credentials import ADMIN_AUTH, CREATOR_AUTH
 from tests.test_jobs import get_job_and_wait_until_ok
+from tests.test_classification import _prj_query
+
+from BO.Prediction import DeepFeatures
+
+from API_operations.CRUD.ObjectParents import SamplesService
 
 OBJECT_SET_PREDICT_URL = "/object_set/predict"
 
@@ -37,3 +45,51 @@ def no_test_basic_prediction(config, database, fastapi, caplog):
     assert rsp.status_code == status.HTTP_200_OK
 
     job_id = get_job_and_wait_until_ok(fastapi, rsp)
+    
+    
+def test_prediction_functions(config, database, fastapi, caplog):
+    caplog.set_level(logging.ERROR)
+    from tests.test_import import test_import
+    prj_id = test_import(config, database, caplog, "Test Prediction")
+
+    obj_ids = _prj_query(fastapi, CREATOR_AUTH, prj_id)
+    assert len(obj_ids) == 8
+    
+    # Prepare fake CNN features to insert
+    features = list()
+    for i, oi in enumerate(obj_ids):
+        features.append([(i+1) * .1] * 50)
+    features_df = pd.DataFrame(features, index=obj_ids)
+    
+    # Test features insertion
+    with SamplesService() as sce:
+        n_inserts = DeepFeatures.save(sce.session, features_df)
+        assert n_inserts == 8
+        sce.session.commit()
+    
+    # Test features retrieval
+    with SamplesService() as sce:
+        ret = DeepFeatures.np_read_for_objects(sce.session, obj_ids)
+        assert (ret == np.array(features, dtype='float32')).all()
+    
+    # Test find_missing without any missing features
+    with SamplesService() as sce:
+        ret = DeepFeatures.find_missing(sce.session, prj_id)
+        assert ret == {}
+        
+    # Test deletion
+    with SamplesService() as sce:
+        n_deletes = DeepFeatures.delete_all(sce.session, prj_id)
+        assert n_deletes == 8
+        sce.session.commit()
+    
+    # Test find_missing after deletion
+    with SamplesService() as sce:
+        ret = DeepFeatures.find_missing(sce.session, prj_id)
+        assert len(ret) == 8
+    
+    # Test features retrieval in empty table, should raise an error
+    with SamplesService() as sce:
+        with pytest.raises(AssertionError):
+            ret = DeepFeatures.np_read_for_objects(sce.session, obj_ids)
+

--- a/py/main.py
+++ b/py/main.py
@@ -1570,6 +1570,8 @@ def classify_auto_object_set(req: ClassifyAutoReq = Body(...),
     """
     assert len(req.target_ids) == len(req.classifications) == len(req.scores), \
         "Need the same number of objects, classifications and scores"
+    assert all(isinstance(score, float) and 0 <= score <= 1 for score in req.scores), \
+        "Scores should be floats between 0 and 1"
     with ObjectManager() as sce:
         with RightsThrower():
             ret, prj_id, changes = sce.classify_auto_set(current_user, req.target_ids, req.classifications, req.scores,


### PR DESCRIPTION
J'ai ajouté les tests dont on avait parlé, notamment : 
- re-prédire des objets prédits avec la même classe, mais en changeant le score
- faire un reset_to_predicted sur des objets validés
- quelques tests sur le revert (un revert après validation, un 2nd revert immédiatement après qui ne change rien, puis un revert après le reset_to_predicted)
- un test sur la gestion des résultats de ML au mauvais format (avec des listes de tailles différentes pour les scores et les classifications, des champs à None et des scores en dehors de [0, 1]).

Ils mériteraient peut-être d'être encore complétés, mais j'ouvre déjà la pull request pour que ce soit plus simple d'en discuter.